### PR TITLE
Deploy and YML Scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Release Creation
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Build Packs
+      run: npm run pullYMLtoLDB
+
+    # get part of the tag after the `v`
+    - name: Extract tag version number
+      id: get_version
+      uses: battila7/get-version-action@v2
+
+    # Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link_version
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'system.json'
+      env:
+        version: ${{steps.get_version.outputs.version-without-v}}
+        url: https://github.com/${{github.repository}}
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+
+    # Create a zip file with all files required by the module to add to the release
+    - run: zip -r ./module.zip module.json README.md LICENSE build/daggerheart.js assets/ packs/ lang/
+
+    # Create a release for this specific version
+    - name: Update Release with Files
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
+        name: ${{ github.event.release.name }}
+        draft: ${{ github.event.release.unpublished }}
+        prerelease: ${{ github.event.release.prerelease }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './system.json, ./system.zip'
+        tag: ${{ github.event.release.tag_name }}
+        body: ${{ github.event.release.body }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+node_modules
+/packs

--- a/module.json
+++ b/module.json
@@ -1,38 +1,35 @@
 {
-  "id": "daggerheart-srd",
-  "title": "Daggerheart SRD Content",
-  "description": "Daggerheart SRD Content as a module.",
-  "authors": [
+    "id": "daggerheart-srd",
+    "title": "Daggerheart SRD",
+    "description": "Daggerheart SRD compendium content",
+    "authors": [
     {
-    "id": "cptn-cosmo",
-    "discord": "cptn-cosmo"
+        "id": "cptn-cosmo",
+        "name": "cptn-cosmo",
+        "discord": "cptn-cosmo"
+    },
+    {
+        "id": "WBHarry",
+        "name": "HarryFurAlle",
+        "discord": "HarryFurAlle"
     }
-  ],
-  "relationships": {
-    "systems": [{
-        "id": "daggerheart",
-        "type": "system",
-        "manifest": "https://github.com/Foundryborne/daggerhear/releases/download/1.0.0/system.json",
-        "compatibility": {
-        "verified": "1.0.0"
-        }
-    }]
-  },
-  "packs": [
+    ],
+    "relationships": {
+        "systems": [{
+            "id": "daggerheart",
+            "type": "system",
+            "manifest": "https://github.com/Foundryborne/daggerhear/releases/download/1.0.0/system.json",
+            "compatibility": {
+            "verified": "1.0.0"
+            }
+        }]
+    },
+    "packs": [
         {
             "name": "classes",
             "label": "Classes",
             "system": "daggerheart",
             "path": "packs/classes.db",
-            "type": "Item",
-            "private": false,
-            "flags": {}
-        },
-        {
-            "name": "class-features",
-            "label": "Class Features",
-            "system": "daggerheart",
-            "path": "packs/class-features.db",
             "type": "Item",
             "private": false,
             "flags": {}
@@ -74,15 +71,6 @@
             "flags": {}
         },
         {
-            "name": "community-features",
-            "label": "Community Features",
-            "system": "daggerheart",
-            "path": "packs/community-features.db",
-            "type": "Item",
-            "private": false,
-            "flags": {}
-        },
-        {
             "name": "weapons",
             "label": "Weapons",
             "system": "daggerheart",
@@ -110,10 +98,10 @@
             "flags": {}
         },
         {
-            "name": "general-items",
-            "label": "General Items",
+            "name": "miscellaneous",
+            "label": "Miscellaneous",
             "system": "daggerheart",
-            "path": "packs/items/general.db",
+            "path": "packs/items/miscellaneous.db",
             "type": "Item",
             "private": false,
             "flags": {}
@@ -150,33 +138,24 @@
                     "color": "#000000",
                     "packs": [
                         "classes",
-                        "class-features",
                         "subclasses",
                         "domains",
                         "ancestries",
-                        "communities",
-                        "community-features"
+                        "communities"
                     ]
                 },
                 {
                     "name": "Items",
                     "sorting": "m",
                     "color": "#000000",
-                    "packs": ["weapons", "armors", "consumables", "general-items"]
+                    "packs": ["weapons", "armors", "consumables", "miscellaneous"]
                 }
             ]
         }
     ],
-    "languages": [
-    {
-      "lang": "en",
-      "name": "English",
-      "path": "lang/en.json"
+    "version": "1.0.0",
+    "compatibility": {
+        "minimum": "13",
+        "verified": "13"
     }
-  ],
-  "version": "1.0.0",
-  "compatibility": {
-    "minimum": "13",
-    "verified": "13"
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,931 @@
+{
+  "name": "daggerheart-srd",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@foundryvtt/foundryvtt-cli": "^1.0.2"
+      }
+    },
+    "node_modules/@foundryvtt/foundryvtt-cli": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@foundryvtt/foundryvtt-cli/-/foundryvtt-cli-1.1.0.tgz",
+      "integrity": "sha512-ergKZDUSgQ79168r38ORyN4v/UTliA40rxElaUh5iS27Qw9H8Ep/ll8j3/HfiikO3XUDwYxZLfDJfbcyj2i9TQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "classic-level": "^1.4.1",
+        "esm": "^3.2.25",
+        "js-yaml": "^4.1.0",
+        "mkdirp": "^3.0.1",
+        "nedb-promises": "^6.2.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "fvtt": "fvtt.mjs"
+      },
+      "engines": {
+        "node": ">17.0.0"
+      }
+    },
+    "node_modules/@seald-io/binary-search-tree": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz",
+      "integrity": "sha512-qv3jnwoakeax2razYaMsGI/luWdliBLHTdC6jU55hQt1hcFqzauH/HsBollQ7IR4ySTtYhT+xyHoijpA16C+tA==",
+      "dev": true
+    },
+    "node_modules/@seald-io/nedb": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@seald-io/nedb/-/nedb-4.1.1.tgz",
+      "integrity": "sha512-u7fVfzKQ/3ZaIOnYQONf2lPZtGUeQtMPjfcaQkCw/GZv5dzn20qKW6sfN0NkVbr0ksJMlWcFXNGcXYsQSb1a1g==",
+      "dev": true,
+      "dependencies": {
+        "@seald-io/binary-search-tree": "^1.0.3",
+        "localforage": "^1.9.0",
+        "util": "^0.12.4"
+      }
+    },
+    "node_modules/abstract-level": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dev": true,
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "dev": true
+    },
+    "node_modules/nedb-promises": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-6.2.3.tgz",
+      "integrity": "sha512-enq0IjNyBz9Qy9W/QPCcLGh/QORGBjXbIeZeWvIjO3OMLyAvlKT3hiJubP2BKEiFniUlR3L01o18ktqgn5jxqA==",
+      "dev": true,
+      "dependencies": {
+        "@seald-io/nedb": "^4.0.2"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "start": "node ../../../../FoundryDev/main.js --dataPath=../../../  --noupnp",
+    "pushLDBtoYML": "node ./tools/pushLDBtoYML.mjs",
+    "pullYMLtoLDB": "node ./tools/pullYMLtoLDB.mjs"
+  },
+  "devDependencies": {
+    "@foundryvtt/foundryvtt-cli": "^1.0.2"
+  }
+}

--- a/src/packs/domains/folders_Arcana_jc1HbSpJmjAsq9GX.json
+++ b/src/packs/domains/folders_Arcana_jc1HbSpJmjAsq9GX.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Arcana",
+  "color": "#562d6c",
+  "sorting": "a",
+  "_id": "jc1HbSpJmjAsq9GX",
+  "description": "",
+  "sort": 100000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605570,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!jc1HbSpJmjAsq9GX"
+}

--- a/src/packs/domains/folders_Blade_gXc5zPwSyZXqrC6D.json
+++ b/src/packs/domains/folders_Blade_gXc5zPwSyZXqrC6D.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Blade",
+  "color": "#923628",
+  "sorting": "a",
+  "_id": "gXc5zPwSyZXqrC6D",
+  "description": "",
+  "sort": 200000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607165,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!gXc5zPwSyZXqrC6D"
+}

--- a/src/packs/domains/folders_Bone_IMRfDo5DDrpniKKv.json
+++ b/src/packs/domains/folders_Bone_IMRfDo5DDrpniKKv.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Bone",
+  "color": "#656768",
+  "sorting": "a",
+  "_id": "IMRfDo5DDrpniKKv",
+  "description": "",
+  "sort": 300000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608315,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!IMRfDo5DDrpniKKv"
+}

--- a/src/packs/domains/folders_Codex_q9VsNwg9r0bTn2ll.json
+++ b/src/packs/domains/folders_Codex_q9VsNwg9r0bTn2ll.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Codex",
+  "color": "#1a315b",
+  "sorting": "a",
+  "_id": "q9VsNwg9r0bTn2ll",
+  "description": "",
+  "sort": 400000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609404,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!q9VsNwg9r0bTn2ll"
+}

--- a/src/packs/domains/folders_Grace_c380soh7Z1YAqzOT.json
+++ b/src/packs/domains/folders_Grace_c380soh7Z1YAqzOT.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Grace",
+  "color": "#7a3961",
+  "sorting": "a",
+  "_id": "c380soh7Z1YAqzOT",
+  "description": "",
+  "sort": 500000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610963,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!c380soh7Z1YAqzOT"
+}

--- a/src/packs/domains/folders_Level_10_7Cs44YADBTmmtCw6.json
+++ b/src/packs/domains/folders_Level_10_7Cs44YADBTmmtCw6.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "7Cs44YADBTmmtCw6",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!7Cs44YADBTmmtCw6"
+}

--- a/src/packs/domains/folders_Level_10_7pKKYgRQAKlQAksV.json
+++ b/src/packs/domains/folders_Level_10_7pKKYgRQAKlQAksV.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "7pKKYgRQAKlQAksV",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!7pKKYgRQAKlQAksV"
+}

--- a/src/packs/domains/folders_Level_10_8qr1Y2tW3vLwNZOg.json
+++ b/src/packs/domains/folders_Level_10_8qr1Y2tW3vLwNZOg.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "8qr1Y2tW3vLwNZOg",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!8qr1Y2tW3vLwNZOg"
+}

--- a/src/packs/domains/folders_Level_10_D1MFCYakdFIKDmcD.json
+++ b/src/packs/domains/folders_Level_10_D1MFCYakdFIKDmcD.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "D1MFCYakdFIKDmcD",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!D1MFCYakdFIKDmcD"
+}

--- a/src/packs/domains/folders_Level_10_Hs6POmXKThDXQJBn.json
+++ b/src/packs/domains/folders_Level_10_Hs6POmXKThDXQJBn.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "Hs6POmXKThDXQJBn",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Hs6POmXKThDXQJBn"
+}

--- a/src/packs/domains/folders_Level_10_IIVaYseNJbA2ta1B.json
+++ b/src/packs/domains/folders_Level_10_IIVaYseNJbA2ta1B.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "IIVaYseNJbA2ta1B",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!IIVaYseNJbA2ta1B"
+}

--- a/src/packs/domains/folders_Level_10_nZr2hsu6Q6TlFXQn.json
+++ b/src/packs/domains/folders_Level_10_nZr2hsu6Q6TlFXQn.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "nZr2hsu6Q6TlFXQn",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!nZr2hsu6Q6TlFXQn"
+}

--- a/src/packs/domains/folders_Level_10_pPzU9WOQNv3ckO1w.json
+++ b/src/packs/domains/folders_Level_10_pPzU9WOQNv3ckO1w.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "pPzU9WOQNv3ckO1w",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!pPzU9WOQNv3ckO1w"
+}

--- a/src/packs/domains/folders_Level_10_wdhWWqWlPiBxtsvr.json
+++ b/src/packs/domains/folders_Level_10_wdhWWqWlPiBxtsvr.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 10",
+  "color": null,
+  "sorting": "a",
+  "_id": "wdhWWqWlPiBxtsvr",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!wdhWWqWlPiBxtsvr"
+}

--- a/src/packs/domains/folders_Level_1_9Xc6KzNyjDtTGZkp.json
+++ b/src/packs/domains/folders_Level_1_9Xc6KzNyjDtTGZkp.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "9Xc6KzNyjDtTGZkp",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!9Xc6KzNyjDtTGZkp"
+}

--- a/src/packs/domains/folders_Level_1_EJoXzO85rG5EiZsh.json
+++ b/src/packs/domains/folders_Level_1_EJoXzO85rG5EiZsh.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "EJoXzO85rG5EiZsh",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!EJoXzO85rG5EiZsh"
+}

--- a/src/packs/domains/folders_Level_1_LlWJaBZOKh0Ot2kD.json
+++ b/src/packs/domains/folders_Level_1_LlWJaBZOKh0Ot2kD.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "LlWJaBZOKh0Ot2kD",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!LlWJaBZOKh0Ot2kD"
+}

--- a/src/packs/domains/folders_Level_1_PeeIjbkBv41613yZ.json
+++ b/src/packs/domains/folders_Level_1_PeeIjbkBv41613yZ.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "PeeIjbkBv41613yZ",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!PeeIjbkBv41613yZ"
+}

--- a/src/packs/domains/folders_Level_1_QpOL7jPbMBzH96qR.json
+++ b/src/packs/domains/folders_Level_1_QpOL7jPbMBzH96qR.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "QpOL7jPbMBzH96qR",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!QpOL7jPbMBzH96qR"
+}

--- a/src/packs/domains/folders_Level_1_nVCKcZkcoEivYJaF.json
+++ b/src/packs/domains/folders_Level_1_nVCKcZkcoEivYJaF.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "nVCKcZkcoEivYJaF",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!nVCKcZkcoEivYJaF"
+}

--- a/src/packs/domains/folders_Level_1_o7kvw9NRGvDZSce2.json
+++ b/src/packs/domains/folders_Level_1_o7kvw9NRGvDZSce2.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "o7kvw9NRGvDZSce2",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!o7kvw9NRGvDZSce2"
+}

--- a/src/packs/domains/folders_Level_1_sCiN7DoysdKceIMd.json
+++ b/src/packs/domains/folders_Level_1_sCiN7DoysdKceIMd.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "sCiN7DoysdKceIMd",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!sCiN7DoysdKceIMd"
+}

--- a/src/packs/domains/folders_Level_1_tqhasjtHBX0F20lN.json
+++ b/src/packs/domains/folders_Level_1_tqhasjtHBX0F20lN.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "tqhasjtHBX0F20lN",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!tqhasjtHBX0F20lN"
+}

--- a/src/packs/domains/folders_Level_2_2yh8wuYprOyswf0r.json
+++ b/src/packs/domains/folders_Level_2_2yh8wuYprOyswf0r.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "2yh8wuYprOyswf0r",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!2yh8wuYprOyswf0r"
+}

--- a/src/packs/domains/folders_Level_2_Abn46nCQst6kpGeA.json
+++ b/src/packs/domains/folders_Level_2_Abn46nCQst6kpGeA.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "Abn46nCQst6kpGeA",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Abn46nCQst6kpGeA"
+}

--- a/src/packs/domains/folders_Level_2_Q9rmrfeKqcqBNnWc.json
+++ b/src/packs/domains/folders_Level_2_Q9rmrfeKqcqBNnWc.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "Q9rmrfeKqcqBNnWc",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Q9rmrfeKqcqBNnWc"
+}

--- a/src/packs/domains/folders_Level_2_j9i2Q6Z7Z82udHn1.json
+++ b/src/packs/domains/folders_Level_2_j9i2Q6Z7Z82udHn1.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "j9i2Q6Z7Z82udHn1",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!j9i2Q6Z7Z82udHn1"
+}

--- a/src/packs/domains/folders_Level_2_o7t2fsAmRxKLoHrO.json
+++ b/src/packs/domains/folders_Level_2_o7t2fsAmRxKLoHrO.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "o7t2fsAmRxKLoHrO",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!o7t2fsAmRxKLoHrO"
+}

--- a/src/packs/domains/folders_Level_2_pk4xXE8D3vTawrqj.json
+++ b/src/packs/domains/folders_Level_2_pk4xXE8D3vTawrqj.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "pk4xXE8D3vTawrqj",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!pk4xXE8D3vTawrqj"
+}

--- a/src/packs/domains/folders_Level_2_pu3xD4rEkdfdAvGc.json
+++ b/src/packs/domains/folders_Level_2_pu3xD4rEkdfdAvGc.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "pu3xD4rEkdfdAvGc",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!pu3xD4rEkdfdAvGc"
+}

--- a/src/packs/domains/folders_Level_2_u8Yz2hUTaF3N2fFT.json
+++ b/src/packs/domains/folders_Level_2_u8Yz2hUTaF3N2fFT.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "u8Yz2hUTaF3N2fFT",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!u8Yz2hUTaF3N2fFT"
+}

--- a/src/packs/domains/folders_Level_2_xZrCYAd05ayNu1yW.json
+++ b/src/packs/domains/folders_Level_2_xZrCYAd05ayNu1yW.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "xZrCYAd05ayNu1yW",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!xZrCYAd05ayNu1yW"
+}

--- a/src/packs/domains/folders_Level_3_7XeaYZPMB0SopAfo.json
+++ b/src/packs/domains/folders_Level_3_7XeaYZPMB0SopAfo.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "7XeaYZPMB0SopAfo",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!7XeaYZPMB0SopAfo"
+}

--- a/src/packs/domains/folders_Level_3_8ZfL09F8MiOEUzzw.json
+++ b/src/packs/domains/folders_Level_3_8ZfL09F8MiOEUzzw.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "8ZfL09F8MiOEUzzw",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!8ZfL09F8MiOEUzzw"
+}

--- a/src/packs/domains/folders_Level_3_GhLhMfmSgGqS9bwU.json
+++ b/src/packs/domains/folders_Level_3_GhLhMfmSgGqS9bwU.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "GhLhMfmSgGqS9bwU",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!GhLhMfmSgGqS9bwU"
+}

--- a/src/packs/domains/folders_Level_3_Oo9EkkF7CDD3QZEG.json
+++ b/src/packs/domains/folders_Level_3_Oo9EkkF7CDD3QZEG.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "Oo9EkkF7CDD3QZEG",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Oo9EkkF7CDD3QZEG"
+}

--- a/src/packs/domains/folders_Level_3_eR7sP5jQwfCLORUe.json
+++ b/src/packs/domains/folders_Level_3_eR7sP5jQwfCLORUe.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "eR7sP5jQwfCLORUe",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!eR7sP5jQwfCLORUe"
+}

--- a/src/packs/domains/folders_Level_3_hoDIPBzwYPxiSXGU.json
+++ b/src/packs/domains/folders_Level_3_hoDIPBzwYPxiSXGU.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "hoDIPBzwYPxiSXGU",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!hoDIPBzwYPxiSXGU"
+}

--- a/src/packs/domains/folders_Level_3_mOv6BGhJAeGrzA84.json
+++ b/src/packs/domains/folders_Level_3_mOv6BGhJAeGrzA84.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "mOv6BGhJAeGrzA84",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!mOv6BGhJAeGrzA84"
+}

--- a/src/packs/domains/folders_Level_3_uXGugK72AffddFdH.json
+++ b/src/packs/domains/folders_Level_3_uXGugK72AffddFdH.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "uXGugK72AffddFdH",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!uXGugK72AffddFdH"
+}

--- a/src/packs/domains/folders_Level_3_wWL9mV6i2EGX5xHS.json
+++ b/src/packs/domains/folders_Level_3_wWL9mV6i2EGX5xHS.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "wWL9mV6i2EGX5xHS",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!wWL9mV6i2EGX5xHS"
+}

--- a/src/packs/domains/folders_Level_4_1e5Sn8OXxEQ57GSD.json
+++ b/src/packs/domains/folders_Level_4_1e5Sn8OXxEQ57GSD.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "1e5Sn8OXxEQ57GSD",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!1e5Sn8OXxEQ57GSD"
+}

--- a/src/packs/domains/folders_Level_4_3e8kCsLzLxiACJDb.json
+++ b/src/packs/domains/folders_Level_4_3e8kCsLzLxiACJDb.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "3e8kCsLzLxiACJDb",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!3e8kCsLzLxiACJDb"
+}

--- a/src/packs/domains/folders_Level_4_BJIiOIWAQUz5zuqo.json
+++ b/src/packs/domains/folders_Level_4_BJIiOIWAQUz5zuqo.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "BJIiOIWAQUz5zuqo",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!BJIiOIWAQUz5zuqo"
+}

--- a/src/packs/domains/folders_Level_4_WTdOLLkQyPdg0KWU.json
+++ b/src/packs/domains/folders_Level_4_WTdOLLkQyPdg0KWU.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "WTdOLLkQyPdg0KWU",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!WTdOLLkQyPdg0KWU"
+}

--- a/src/packs/domains/folders_Level_4_cOZgzLQRGNnBzsHT.json
+++ b/src/packs/domains/folders_Level_4_cOZgzLQRGNnBzsHT.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "cOZgzLQRGNnBzsHT",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!cOZgzLQRGNnBzsHT"
+}

--- a/src/packs/domains/folders_Level_4_rUGDM9JvGfhh9a2Y.json
+++ b/src/packs/domains/folders_Level_4_rUGDM9JvGfhh9a2Y.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "rUGDM9JvGfhh9a2Y",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!rUGDM9JvGfhh9a2Y"
+}

--- a/src/packs/domains/folders_Level_4_thP6nUk0nkrNcpXY.json
+++ b/src/packs/domains/folders_Level_4_thP6nUk0nkrNcpXY.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "thP6nUk0nkrNcpXY",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!thP6nUk0nkrNcpXY"
+}

--- a/src/packs/domains/folders_Level_4_vAZKNDtAafd7HDWV.json
+++ b/src/packs/domains/folders_Level_4_vAZKNDtAafd7HDWV.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "vAZKNDtAafd7HDWV",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!vAZKNDtAafd7HDWV"
+}

--- a/src/packs/domains/folders_Level_4_yalAnCU3SndrYImF.json
+++ b/src/packs/domains/folders_Level_4_yalAnCU3SndrYImF.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "yalAnCU3SndrYImF",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!yalAnCU3SndrYImF"
+}

--- a/src/packs/domains/folders_Level_5_6gA7SmNIblkMaYgr.json
+++ b/src/packs/domains/folders_Level_5_6gA7SmNIblkMaYgr.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "6gA7SmNIblkMaYgr",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!6gA7SmNIblkMaYgr"
+}

--- a/src/packs/domains/folders_Level_5_8erksbTp7ic6in4I.json
+++ b/src/packs/domains/folders_Level_5_8erksbTp7ic6in4I.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "8erksbTp7ic6in4I",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!8erksbTp7ic6in4I"
+}

--- a/src/packs/domains/folders_Level_5_BQ1L4EiwOs84Xysp.json
+++ b/src/packs/domains/folders_Level_5_BQ1L4EiwOs84Xysp.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "BQ1L4EiwOs84Xysp",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!BQ1L4EiwOs84Xysp"
+}

--- a/src/packs/domains/folders_Level_5_Emnx4o1DWGTVKoAg.json
+++ b/src/packs/domains/folders_Level_5_Emnx4o1DWGTVKoAg.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "Emnx4o1DWGTVKoAg",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Emnx4o1DWGTVKoAg"
+}

--- a/src/packs/domains/folders_Level_5_Jbw6Teaha6So9tym.json
+++ b/src/packs/domains/folders_Level_5_Jbw6Teaha6So9tym.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "Jbw6Teaha6So9tym",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Jbw6Teaha6So9tym"
+}

--- a/src/packs/domains/folders_Level_5_XDSp0FdiYDVO0tfw.json
+++ b/src/packs/domains/folders_Level_5_XDSp0FdiYDVO0tfw.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "XDSp0FdiYDVO0tfw",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!XDSp0FdiYDVO0tfw"
+}

--- a/src/packs/domains/folders_Level_5_ZZHIbaynhzVArA1p.json
+++ b/src/packs/domains/folders_Level_5_ZZHIbaynhzVArA1p.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "ZZHIbaynhzVArA1p",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!ZZHIbaynhzVArA1p"
+}

--- a/src/packs/domains/folders_Level_5_l387HKojhqcDAV0b.json
+++ b/src/packs/domains/folders_Level_5_l387HKojhqcDAV0b.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "l387HKojhqcDAV0b",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!l387HKojhqcDAV0b"
+}

--- a/src/packs/domains/folders_Level_5_pDtffkb0SMv1O8pL.json
+++ b/src/packs/domains/folders_Level_5_pDtffkb0SMv1O8pL.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 5",
+  "color": null,
+  "sorting": "a",
+  "_id": "pDtffkb0SMv1O8pL",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!pDtffkb0SMv1O8pL"
+}

--- a/src/packs/domains/folders_Level_6_EiP5dLozOFZKIeWN.json
+++ b/src/packs/domains/folders_Level_6_EiP5dLozOFZKIeWN.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "EiP5dLozOFZKIeWN",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!EiP5dLozOFZKIeWN"
+}

--- a/src/packs/domains/folders_Level_6_FcMclsLDy86EicA6.json
+++ b/src/packs/domains/folders_Level_6_FcMclsLDy86EicA6.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "FcMclsLDy86EicA6",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!FcMclsLDy86EicA6"
+}

--- a/src/packs/domains/folders_Level_6_OwsbTSWzKq2WJmQN.json
+++ b/src/packs/domains/folders_Level_6_OwsbTSWzKq2WJmQN.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "OwsbTSWzKq2WJmQN",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!OwsbTSWzKq2WJmQN"
+}

--- a/src/packs/domains/folders_Level_6_VgADdqYn9nS9G1Us.json
+++ b/src/packs/domains/folders_Level_6_VgADdqYn9nS9G1Us.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "VgADdqYn9nS9G1Us",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!VgADdqYn9nS9G1Us"
+}

--- a/src/packs/domains/folders_Level_6_gqnmAgerh7HhNo7t.json
+++ b/src/packs/domains/folders_Level_6_gqnmAgerh7HhNo7t.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "gqnmAgerh7HhNo7t",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!gqnmAgerh7HhNo7t"
+}

--- a/src/packs/domains/folders_Level_6_nKCmeAn7ESsb4byE.json
+++ b/src/packs/domains/folders_Level_6_nKCmeAn7ESsb4byE.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "nKCmeAn7ESsb4byE",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!nKCmeAn7ESsb4byE"
+}

--- a/src/packs/domains/folders_Level_6_pYEavNqteiQepvvD.json
+++ b/src/packs/domains/folders_Level_6_pYEavNqteiQepvvD.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "pYEavNqteiQepvvD",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!pYEavNqteiQepvvD"
+}

--- a/src/packs/domains/folders_Level_6_u5Lq2kfC8LlDAGDC.json
+++ b/src/packs/domains/folders_Level_6_u5Lq2kfC8LlDAGDC.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "u5Lq2kfC8LlDAGDC",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!u5Lq2kfC8LlDAGDC"
+}

--- a/src/packs/domains/folders_Level_6_xuGz0QPNlkTOV0rV.json
+++ b/src/packs/domains/folders_Level_6_xuGz0QPNlkTOV0rV.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 6",
+  "color": null,
+  "sorting": "a",
+  "_id": "xuGz0QPNlkTOV0rV",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!xuGz0QPNlkTOV0rV"
+}

--- a/src/packs/domains/folders_Level_7_HAGbPLHwm0UozDeG.json
+++ b/src/packs/domains/folders_Level_7_HAGbPLHwm0UozDeG.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "HAGbPLHwm0UozDeG",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!HAGbPLHwm0UozDeG"
+}

--- a/src/packs/domains/folders_Level_7_ML2JusN36oJoR8QA.json
+++ b/src/packs/domains/folders_Level_7_ML2JusN36oJoR8QA.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "ML2JusN36oJoR8QA",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!ML2JusN36oJoR8QA"
+}

--- a/src/packs/domains/folders_Level_7_W81LnTWzwmoaycTl.json
+++ b/src/packs/domains/folders_Level_7_W81LnTWzwmoaycTl.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "W81LnTWzwmoaycTl",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!W81LnTWzwmoaycTl"
+}

--- a/src/packs/domains/folders_Level_7_Z6oglw8LIOrtBcN6.json
+++ b/src/packs/domains/folders_Level_7_Z6oglw8LIOrtBcN6.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "Z6oglw8LIOrtBcN6",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!Z6oglw8LIOrtBcN6"
+}

--- a/src/packs/domains/folders_Level_7_bCjkysrofWPiZqNh.json
+++ b/src/packs/domains/folders_Level_7_bCjkysrofWPiZqNh.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "bCjkysrofWPiZqNh",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!bCjkysrofWPiZqNh"
+}

--- a/src/packs/domains/folders_Level_7_gEVGjjPrjqxxZkb5.json
+++ b/src/packs/domains/folders_Level_7_gEVGjjPrjqxxZkb5.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "gEVGjjPrjqxxZkb5",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!gEVGjjPrjqxxZkb5"
+}

--- a/src/packs/domains/folders_Level_7_hh2vkggcAQ0QUE6C.json
+++ b/src/packs/domains/folders_Level_7_hh2vkggcAQ0QUE6C.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "hh2vkggcAQ0QUE6C",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!hh2vkggcAQ0QUE6C"
+}

--- a/src/packs/domains/folders_Level_7_i5iDLXMZLc0ckWI5.json
+++ b/src/packs/domains/folders_Level_7_i5iDLXMZLc0ckWI5.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "i5iDLXMZLc0ckWI5",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!i5iDLXMZLc0ckWI5"
+}

--- a/src/packs/domains/folders_Level_7_kj3gwg5bmCqwFYze.json
+++ b/src/packs/domains/folders_Level_7_kj3gwg5bmCqwFYze.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 7",
+  "color": null,
+  "sorting": "a",
+  "_id": "kj3gwg5bmCqwFYze",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!kj3gwg5bmCqwFYze"
+}

--- a/src/packs/domains/folders_Level_8_7O1tTswJMNdPgLsx.json
+++ b/src/packs/domains/folders_Level_8_7O1tTswJMNdPgLsx.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "7O1tTswJMNdPgLsx",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!7O1tTswJMNdPgLsx"
+}

--- a/src/packs/domains/folders_Level_8_8bWpGblWODdf8mDR.json
+++ b/src/packs/domains/folders_Level_8_8bWpGblWODdf8mDR.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "8bWpGblWODdf8mDR",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!8bWpGblWODdf8mDR"
+}

--- a/src/packs/domains/folders_Level_8_A00z8Q8B3aKApKzI.json
+++ b/src/packs/domains/folders_Level_8_A00z8Q8B3aKApKzI.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "A00z8Q8B3aKApKzI",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!A00z8Q8B3aKApKzI"
+}

--- a/src/packs/domains/folders_Level_8_FUzQxkv4gFc46SIs.json
+++ b/src/packs/domains/folders_Level_8_FUzQxkv4gFc46SIs.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "FUzQxkv4gFc46SIs",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!FUzQxkv4gFc46SIs"
+}

--- a/src/packs/domains/folders_Level_8_KmaX6wNBLzkFevaG.json
+++ b/src/packs/domains/folders_Level_8_KmaX6wNBLzkFevaG.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "KmaX6wNBLzkFevaG",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!KmaX6wNBLzkFevaG"
+}

--- a/src/packs/domains/folders_Level_8_me7ywrVh38j6T8Sm.json
+++ b/src/packs/domains/folders_Level_8_me7ywrVh38j6T8Sm.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "me7ywrVh38j6T8Sm",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!me7ywrVh38j6T8Sm"
+}

--- a/src/packs/domains/folders_Level_8_n7pgTBYSItMzCX0s.json
+++ b/src/packs/domains/folders_Level_8_n7pgTBYSItMzCX0s.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "n7pgTBYSItMzCX0s",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!n7pgTBYSItMzCX0s"
+}

--- a/src/packs/domains/folders_Level_8_qY4Zqc1Ch6p317uK.json
+++ b/src/packs/domains/folders_Level_8_qY4Zqc1Ch6p317uK.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "qY4Zqc1Ch6p317uK",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!qY4Zqc1Ch6p317uK"
+}

--- a/src/packs/domains/folders_Level_8_taM81THa8h6Bv2Xa.json
+++ b/src/packs/domains/folders_Level_8_taM81THa8h6Bv2Xa.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 8",
+  "color": null,
+  "sorting": "a",
+  "_id": "taM81THa8h6Bv2Xa",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!taM81THa8h6Bv2Xa"
+}

--- a/src/packs/domains/folders_Level_9_2rqOUxEglhhPKk2j.json
+++ b/src/packs/domains/folders_Level_9_2rqOUxEglhhPKk2j.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "tgwSE1t5B0Ka10Xh",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "2rqOUxEglhhPKk2j",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612076,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!2rqOUxEglhhPKk2j"
+}

--- a/src/packs/domains/folders_Level_9_8DOVMjTtZFKtwX4p.json
+++ b/src/packs/domains/folders_Level_9_8DOVMjTtZFKtwX4p.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "yPVeShe47ETIqs9q",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "8DOVMjTtZFKtwX4p",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615516,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!8DOVMjTtZFKtwX4p"
+}

--- a/src/packs/domains/folders_Level_9_KwZYrsSUYnHiNtPl.json
+++ b/src/packs/domains/folders_Level_9_KwZYrsSUYnHiNtPl.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "q9VsNwg9r0bTn2ll",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "KwZYrsSUYnHiNtPl",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372609395,
+    "modifiedTime": 1751372609395,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!KwZYrsSUYnHiNtPl"
+}

--- a/src/packs/domains/folders_Level_9_QYdeGsmVYIF34kZR.json
+++ b/src/packs/domains/folders_Level_9_QYdeGsmVYIF34kZR.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "gXc5zPwSyZXqrC6D",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "QYdeGsmVYIF34kZR",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372607154,
+    "modifiedTime": 1751372607154,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!QYdeGsmVYIF34kZR"
+}

--- a/src/packs/domains/folders_Level_9_R5afi5bhq9ccnYY2.json
+++ b/src/packs/domains/folders_Level_9_R5afi5bhq9ccnYY2.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "io1DZ9MMMDfuNf8b",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "R5afi5bhq9ccnYY2",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613251,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!R5afi5bhq9ccnYY2"
+}

--- a/src/packs/domains/folders_Level_9_eg2vM8j9xhya9Rwa.json
+++ b/src/packs/domains/folders_Level_9_eg2vM8j9xhya9Rwa.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "IMRfDo5DDrpniKKv",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "eg2vM8j9xhya9Rwa",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372608309,
+    "modifiedTime": 1751372608309,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!eg2vM8j9xhya9Rwa"
+}

--- a/src/packs/domains/folders_Level_9_fucNnucgoUjbzvcA.json
+++ b/src/packs/domains/folders_Level_9_fucNnucgoUjbzvcA.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "jc1HbSpJmjAsq9GX",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "fucNnucgoUjbzvcA",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372605554,
+    "modifiedTime": 1751372605554,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!fucNnucgoUjbzvcA"
+}

--- a/src/packs/domains/folders_Level_9_sGCKwmomutMTv0Xs.json
+++ b/src/packs/domains/folders_Level_9_sGCKwmomutMTv0Xs.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "TL1TutmbeCVJ06nR",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "sGCKwmomutMTv0Xs",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614418,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!sGCKwmomutMTv0Xs"
+}

--- a/src/packs/domains/folders_Level_9_yFcD1LOM3xKbkNYl.json
+++ b/src/packs/domains/folders_Level_9_yFcD1LOM3xKbkNYl.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": "c380soh7Z1YAqzOT",
+  "name": "Level 9",
+  "color": null,
+  "sorting": "a",
+  "_id": "yFcD1LOM3xKbkNYl",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372610954,
+    "modifiedTime": 1751372610954,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!yFcD1LOM3xKbkNYl"
+}

--- a/src/packs/domains/folders_Midnight_tgwSE1t5B0Ka10Xh.json
+++ b/src/packs/domains/folders_Midnight_tgwSE1t5B0Ka10Xh.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Midnight",
+  "color": "#26252b",
+  "sorting": "a",
+  "_id": "tgwSE1t5B0Ka10Xh",
+  "description": "",
+  "sort": 600000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372612076,
+    "modifiedTime": 1751372612084,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!tgwSE1t5B0Ka10Xh"
+}

--- a/src/packs/domains/folders_Sage_io1DZ9MMMDfuNf8b.json
+++ b/src/packs/domains/folders_Sage_io1DZ9MMMDfuNf8b.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Sage",
+  "color": "#0a5932",
+  "sorting": "a",
+  "_id": "io1DZ9MMMDfuNf8b",
+  "description": "",
+  "sort": 700000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372613251,
+    "modifiedTime": 1751372613260,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!io1DZ9MMMDfuNf8b"
+}

--- a/src/packs/domains/folders_Splendor_TL1TutmbeCVJ06nR.json
+++ b/src/packs/domains/folders_Splendor_TL1TutmbeCVJ06nR.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Splendor",
+  "color": "#c79b44",
+  "sorting": "a",
+  "_id": "TL1TutmbeCVJ06nR",
+  "description": "",
+  "sort": 800000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372614418,
+    "modifiedTime": 1751372614427,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!TL1TutmbeCVJ06nR"
+}

--- a/src/packs/domains/folders_Valor_yPVeShe47ETIqs9q.json
+++ b/src/packs/domains/folders_Valor_yPVeShe47ETIqs9q.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Valor",
+  "color": "#b07229",
+  "sorting": "a",
+  "_id": "yPVeShe47ETIqs9q",
+  "description": "",
+  "sort": 900000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372615516,
+    "modifiedTime": 1751372615525,
+    "lastModifiedBy": "EhY0UV2lYpQcmdoD"
+  },
+  "_key": "!folders!yPVeShe47ETIqs9q"
+}

--- a/src/packs/items/armors/folders_Tier_1_EMUbztsrPsvgPDh2.json
+++ b/src/packs/items/armors/folders_Tier_1_EMUbztsrPsvgPDh2.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "EMUbztsrPsvgPDh2",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372210779,
+    "modifiedTime": 1751372210779,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!EMUbztsrPsvgPDh2"
+}

--- a/src/packs/items/armors/folders_Tier_2_XP3TQDC5RPLweK0O.json
+++ b/src/packs/items/armors/folders_Tier_2_XP3TQDC5RPLweK0O.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "XP3TQDC5RPLweK0O",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372214357,
+    "modifiedTime": 1751372214357,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!XP3TQDC5RPLweK0O"
+}

--- a/src/packs/items/armors/folders_Tier_3_SBY5dncnTwG0n4j4.json
+++ b/src/packs/items/armors/folders_Tier_3_SBY5dncnTwG0n4j4.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "SBY5dncnTwG0n4j4",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372217892,
+    "modifiedTime": 1751372217892,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!SBY5dncnTwG0n4j4"
+}

--- a/src/packs/items/armors/folders_Tier_4_XyBNDN8I71KPWK6s.json
+++ b/src/packs/items/armors/folders_Tier_4_XyBNDN8I71KPWK6s.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "XyBNDN8I71KPWK6s",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372223494,
+    "modifiedTime": 1751372223494,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!XyBNDN8I71KPWK6s"
+}

--- a/src/packs/items/weapons/folders_Tier_1_AEB3edPW1M1CYsQ0.json
+++ b/src/packs/items/weapons/folders_Tier_1_AEB3edPW1M1CYsQ0.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 1",
+  "color": null,
+  "sorting": "a",
+  "_id": "AEB3edPW1M1CYsQ0",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372170348,
+    "modifiedTime": 1751372193592,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!AEB3edPW1M1CYsQ0"
+}

--- a/src/packs/items/weapons/folders_Tier_2_mcWCRd250izmc66W.json
+++ b/src/packs/items/weapons/folders_Tier_2_mcWCRd250izmc66W.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 2",
+  "color": null,
+  "sorting": "a",
+  "_id": "mcWCRd250izmc66W",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372178442,
+    "modifiedTime": 1751372178442,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!mcWCRd250izmc66W"
+}

--- a/src/packs/items/weapons/folders_Tier_3_dQTLTPEDRpeKw6A4.json
+++ b/src/packs/items/weapons/folders_Tier_3_dQTLTPEDRpeKw6A4.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 3",
+  "color": null,
+  "sorting": "a",
+  "_id": "dQTLTPEDRpeKw6A4",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372184633,
+    "modifiedTime": 1751372188984,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!dQTLTPEDRpeKw6A4"
+}

--- a/src/packs/items/weapons/folders_Tier_4_EOX7smzEtWNOWA8J.json
+++ b/src/packs/items/weapons/folders_Tier_4_EOX7smzEtWNOWA8J.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Tier 4",
+  "color": null,
+  "sorting": "a",
+  "_id": "EOX7smzEtWNOWA8J",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372198982,
+    "modifiedTime": 1751372198982,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!EOX7smzEtWNOWA8J"
+}

--- a/src/packs/subclasses/folders_Bard_GdwNrxosxgFCMwUJ.json
+++ b/src/packs/subclasses/folders_Bard_GdwNrxosxgFCMwUJ.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Bard",
+  "color": null,
+  "sorting": "a",
+  "_id": "GdwNrxosxgFCMwUJ",
+  "description": "",
+  "sort": 100000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372295373,
+    "modifiedTime": 1751372295396,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!GdwNrxosxgFCMwUJ"
+}

--- a/src/packs/subclasses/folders_Druid_8o3AE33T1pSQH296.json
+++ b/src/packs/subclasses/folders_Druid_8o3AE33T1pSQH296.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Druid",
+  "color": null,
+  "sorting": "a",
+  "_id": "8o3AE33T1pSQH296",
+  "description": "",
+  "sort": 200000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372296655,
+    "modifiedTime": 1751372296661,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!8o3AE33T1pSQH296"
+}

--- a/src/packs/subclasses/folders_Guardian_GECczaEI6KI9W7B7.json
+++ b/src/packs/subclasses/folders_Guardian_GECczaEI6KI9W7B7.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Guardian",
+  "color": null,
+  "sorting": "a",
+  "_id": "GECczaEI6KI9W7B7",
+  "description": "",
+  "sort": 300000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372297763,
+    "modifiedTime": 1751372297768,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!GECczaEI6KI9W7B7"
+}

--- a/src/packs/subclasses/folders_Ranger_cTmpeni3Jg55NkX4.json
+++ b/src/packs/subclasses/folders_Ranger_cTmpeni3Jg55NkX4.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Ranger",
+  "color": null,
+  "sorting": "a",
+  "_id": "cTmpeni3Jg55NkX4",
+  "description": "",
+  "sort": 400000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372299128,
+    "modifiedTime": 1751372299133,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!cTmpeni3Jg55NkX4"
+}

--- a/src/packs/subclasses/folders_Rogue_2ifNVaI1HZtXVSdf.json
+++ b/src/packs/subclasses/folders_Rogue_2ifNVaI1HZtXVSdf.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Rogue",
+  "color": null,
+  "sorting": "a",
+  "_id": "2ifNVaI1HZtXVSdf",
+  "description": "",
+  "sort": 500000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372300336,
+    "modifiedTime": 1751372300340,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!2ifNVaI1HZtXVSdf"
+}

--- a/src/packs/subclasses/folders_Seraph_8fx2IqJphzGyrZbx.json
+++ b/src/packs/subclasses/folders_Seraph_8fx2IqJphzGyrZbx.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Seraph",
+  "color": null,
+  "sorting": "a",
+  "_id": "8fx2IqJphzGyrZbx",
+  "description": "",
+  "sort": 600000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372301380,
+    "modifiedTime": 1751372301384,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!8fx2IqJphzGyrZbx"
+}

--- a/src/packs/subclasses/folders_Sorcerer_3H1ThzHW4rZStZrr.json
+++ b/src/packs/subclasses/folders_Sorcerer_3H1ThzHW4rZStZrr.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Sorcerer",
+  "color": null,
+  "sorting": "a",
+  "_id": "3H1ThzHW4rZStZrr",
+  "description": "",
+  "sort": 700000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372302523,
+    "modifiedTime": 1751372302528,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!3H1ThzHW4rZStZrr"
+}

--- a/src/packs/subclasses/folders_Warrior_OzZ4UX9B6eNEzF49.json
+++ b/src/packs/subclasses/folders_Warrior_OzZ4UX9B6eNEzF49.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Warrior",
+  "color": null,
+  "sorting": "a",
+  "_id": "OzZ4UX9B6eNEzF49",
+  "description": "",
+  "sort": 800000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372303421,
+    "modifiedTime": 1751372303425,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!OzZ4UX9B6eNEzF49"
+}

--- a/src/packs/subclasses/folders_Wizard_H1Djv0I92cn25M4t.json
+++ b/src/packs/subclasses/folders_Wizard_H1Djv0I92cn25M4t.json
@@ -1,0 +1,23 @@
+{
+  "type": "Item",
+  "folder": null,
+  "name": "Wizard",
+  "color": null,
+  "sorting": "a",
+  "_id": "H1Djv0I92cn25M4t",
+  "description": "",
+  "sort": 900000,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "daggerheart",
+    "systemVersion": "0.0.1",
+    "createdTime": 1751372304320,
+    "modifiedTime": 1751372304325,
+    "lastModifiedBy": "XH8otQcRtKJUxLsz"
+  },
+  "_key": "!folders!H1Djv0I92cn25M4t"
+}

--- a/tools/pullYMLtoLDB.mjs
+++ b/tools/pullYMLtoLDB.mjs
@@ -1,0 +1,31 @@
+import { compilePack } from '@foundryvtt/foundryvtt-cli';
+import { promises as fs } from 'fs';
+
+const MODULE_ID = process.cwd();
+const yaml = false;
+
+const packs = await deepGetDirectories('./packs');
+console.log(packs);
+for (const pack of packs) {
+    if (pack === '.gitattributes') continue;
+    console.log('Packing ' + pack);
+    await compilePack(`${MODULE_ID}/src/${pack}`, `${MODULE_ID}/${pack}`, { yaml });
+}
+
+async function deepGetDirectories(distPath) {
+    const dirr = await fs.readdir('src/' + distPath);
+    const dirrsWithSub = [];
+    for (let file of dirr) {
+        const stat = await fs.stat('src/' + distPath + '/' + file);
+        if (stat.isDirectory()) {
+            const deeper = await deepGetDirectories(distPath + '/' + file);
+            if (deeper.length > 0) {
+                dirrsWithSub.push(...deeper);
+            } else {
+                dirrsWithSub.push(distPath + '/' + file);
+            }
+        }
+    }
+
+    return dirrsWithSub;
+}

--- a/tools/pushLDBtoYML.mjs
+++ b/tools/pushLDBtoYML.mjs
@@ -1,0 +1,58 @@
+import { extractPack } from '@foundryvtt/foundryvtt-cli';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const MODULE_ID = process.cwd();
+const yaml = false;
+
+// const packs = await fs.readdir('./packs');
+const packs = await deepGetDirectories('./packs');
+console.log(packs);
+for (const pack of packs) {
+    if (pack === '.gitattributes') continue;
+    console.log('Unpacking ' + pack);
+    const directory = `./src/${pack}`;
+    try {
+        for (const file of await fs.readdir(directory)) {
+            await fs.unlink(path.join(directory, file));
+        }
+    } catch (error) {
+        if (error.code === 'ENOENT') console.log('No files inside of ' + pack);
+        else console.log(error);
+    }
+    await extractPack(`${MODULE_ID}/${pack}`, `${MODULE_ID}/src/${pack}`, {
+        yaml,
+        transformName
+    });
+}
+/**
+ * Prefaces the document with its type
+ * @param {object} doc - The document data
+ */
+function transformName(doc) {
+    const safeFileName = doc.name.replace(/[^a-zA-Z0-9А-я]/g, '_');
+    const type = doc._key.split('!')[1];
+    const prefix = ['actors', 'items'].includes(type) ? doc.type : type;
+
+    return `${doc.name ? `${prefix}_${safeFileName}_${doc._id}` : doc._id}.${yaml ? 'yml' : 'json'}`;
+}
+
+async function deepGetDirectories(distPath) {
+    const dirr = await fs.readdir(distPath);
+    const dirrsWithSub = [];
+    for (let file of dirr) {
+        const stat = await fs.stat(distPath + '/' + file);
+        if (stat.isDirectory()) {
+            if (file === 'packs') continue;
+
+            const deeper = await deepGetDirectories(distPath + '/' + file);
+            if (deeper.length > 0) {
+                dirrsWithSub.push(...deeper);
+            } else {
+                dirrsWithSub.push(distPath + '/' + file);
+            }
+        }
+    }
+
+    return dirrsWithSub;
+}


### PR DESCRIPTION
Added yml->ldb handling and deploy scripts

Should have the same setup that was in the Daggerheart system originally now.
`npm run pullYMLtoLDB` --> Setup your system compendiums from the YML storage
`npm run pushLDBtoYML` --> Update the YML storage based on your system compendiums

When deploying a version, the packs should automatically be generated in the module files. Going to have to test it once the PR is in though.